### PR TITLE
Use NEEDS in KISWhiteList.cfg

### DIFF
--- a/GameData/CrewLight/MMPatch/KISWhiteList.cfg
+++ b/GameData/CrewLight/MMPatch/KISWhiteList.cfg
@@ -1,4 +1,4 @@
-@KISConfig[KISConfig]:NEED[KIS]:FOR[CrewLight]
+@KISConfig[KISConfig]:NEEDS[KIS]:FOR[CrewLight]
 {
 	@StackableModule
 	{


### PR DESCRIPTION
Corrects the following warning:

`[ModuleManager] unrecognized tag: 'NEED' on: CrewLight/MMPatch/KISWhiteList/@KISConfig[KISConfig]:NEED[KIS]:FOR[CrewLight]`

(unsure whether this should go to master or DEV)